### PR TITLE
Document non-interactive font installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,16 @@ This repository contains a multi-project .NET solution.
    sudo apt-get install -y dotnet-sdk-8.0
    ```
 
-2. Install Ghostscript and Microsoft TrueType fonts (required for image-based tests):
+2. Install Ghostscript and Microsoft TrueType fonts (required for image-based tests).
+   The `ttf-mscorefonts-installer` package prompts for acceptance of the Microsoft EULA and will otherwise block waiting for input.
+   To install non-interactively, pre-accept the license and then install:
 
    ```bash
+   echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
    sudo apt-get install -y ghostscript ttf-mscorefonts-installer
-   fc-cache -f -v
+   fc-cache -f -v  # refresh the font cache
    ```
+   (If you run the install command without pre-accepting the EULA, be prepared to confirm it manually when prompted.)
 
 ## Build
 


### PR DESCRIPTION
## Summary
- explain that ttf-mscorefonts-installer blocks waiting for EULA acceptance
- add commands to pre-accept the license and refresh the font cache

## Testing
- `dotnet build PdfSharpCore.sln`
- `dotnet test --framework net8.0 PdfSharpCore.Test/PdfSharpCore.Test.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689fa8d5a6cc8325a707558fc792eeb1